### PR TITLE
Adding processor-specific template names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,10 @@ Release History
 * Introduce logging through `structlog` and provide more informative logging
   out put to make SAML flows easier to debug. Log messages are all logged under
   the `saml2idp` logger now.
+* Adding a new-style processor that carries a `name` attribute which allows
+  custom templates for each processor during the SSO process. Custom templates
+  are optional and will default to the same templates as before. The change is
+  backwards compatible and handles old-style processors as previously.
 
 
 0.21.2 (2016-04-18)

--- a/idptest/tests/test_registry.py
+++ b/idptest/tests/test_registry.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
+from mock import patch
+
+from saml2idp import registry
+from saml2idp import saml2idp_metadata
+from saml2idp.base import Processor
+
+
+class OldStyleProcessor(Processor):
+
+    def __init__(self, config):
+        super(OldStyleProcessor, self).__init__(config)
+
+
+class NewStyleProcessor(Processor):
+    pass
+
+
+
+def test_getting_old_style_processor():
+    sp_name = 'old_style'
+    sp_config = {'processor': 'tests.test_registry.OldStyleProcessor',
+                 'acs_url': 'http://somwhere.com'}
+
+    with patch('warnings.warn') as warn:
+        instance = registry.get_processor(sp_name, sp_config)
+        assert instance.name == sp_name
+        assert instance._config == sp_config
+        assert warn.call_count == 1
+
+
+def test_getting_new_style_processor():
+    sp_name = 'new_style'
+    sp_config = {'processor': 'tests.test_registry.NewStyleProcessor',
+                 'acs_url': 'http://somwhere.com'}
+
+    with patch('warnings.warn') as warn:
+        instance = registry.get_processor(sp_name, sp_config)
+        assert instance.name == sp_name
+        assert instance._config == sp_config
+        assert warn.call_count == 0

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -7,6 +7,7 @@ Testing actual SAML functionality requires implementation-specific details,
 which should be put in another test module.
 """
 from __future__ import absolute_import
+import os
 import mock
 import pytest
 
@@ -139,7 +140,7 @@ def test_rendering_metadata_view(client):
 def test_creating_template_names_without_processor():
     filename = 'special_file.html'
     template_names = views._get_template_names(filename)
-    assert  template_names == ['{}/{}'.format(views.BASE_TEMPLATE_DIR, filename)]
+    assert template_names == [os.path.join(views.BASE_TEMPLATE_DIR, filename)]
 
 
 def test_creating_template_names_with_processor():
@@ -150,7 +151,7 @@ def test_creating_template_names_with_processor():
     template_names = views._get_template_names(filename, processor)
 
     expected_template_names = [
-        '{}/{}/{}'.format(views.BASE_TEMPLATE_DIR, processor.name, filename),
-        '{}/{}'.format(views.BASE_TEMPLATE_DIR, filename)]
+        os.path.join(views.BASE_TEMPLATE_DIR, processor.name, filename),
+        os.path.join(views.BASE_TEMPLATE_DIR, filename)]
 
-    assert  template_names == expected_template_names
+    assert template_names == expected_template_names

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-django
+pytest-cover
 pdbpp
 tox
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ bumpversion==0.5.3
 setuptools
 twine
 wheel
+mock==1.3.0

--- a/saml2idp/base.py
+++ b/saml2idp/base.py
@@ -43,7 +43,8 @@ class Processor(object):
             module=self.__module__,
             class_name=self.__class__.__name__)
 
-    def __init__(self, config):
+    def __init__(self, config, name=None):
+        self.name = name
         self._config = config.copy()
         self._logger = get_saml_logger()
 

--- a/saml2idp/metadata.py
+++ b/saml2idp/metadata.py
@@ -24,7 +24,7 @@ def get_config_for_resource(resource_name):
         links = get_links(config)
         for name, pattern in links:
             if name == resource_name:
-                return config
+                return friendlyname, config
     msg = 'SAML2IDP_REMOTES is not configured to handle a link resource "%s"'
     raise ImproperlyConfigured(msg % resource_name)
 

--- a/saml2idp/registry.py
+++ b/saml2idp/registry.py
@@ -1,4 +1,4 @@
- -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 """
 Registers and loads Processor classes from settings.

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -140,7 +140,7 @@ def logout(request):
     else:
         return HttpResponseRedirect(redirect_url)
 
-    return render_to_response(_get_template_names('saml2idp/logged_out.html'),
+    return render_to_response(_get_template_names('logged_out.html'),
                               {},
                               context_instance=RequestContext(request))
 

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import os
+
 from django.contrib import auth
 from django.core.validators import URLValidator
 from django.contrib.auth.decorators import login_required
@@ -27,6 +29,21 @@ try:
 except TypeError:
     URL_VALIDATOR = URLValidator()
 
+BASE_TEMPLATE_DIR = 'saml2idp'
+
+
+def _get_template_names(filename, processor=None):
+    """
+    Create a list of template names to use based on the processor name. This
+    makes it possible to have processor-specific templates.
+    """
+    specific_templates = []
+    if processor and processor.name:
+        specific_templates = [
+            os.path.join(BASE_TEMPLATE_DIR, processor.name, filename)]
+
+    return specific_templates + [os.path.join(BASE_TEMPLATE_DIR, filename)]
+
 
 def _generate_response(request, processor):
     """
@@ -36,10 +53,13 @@ def _generate_response(request, processor):
     try:
         tv = processor.generate_response()
     except exceptions.UserNotAuthorized:
-        return render_to_response('saml2idp/invalid_user.html',
+        template_names = _get_template_names('invalid_user.html', processor)
+        return render_to_response(template_names,
                                   context_instance=RequestContext(request))
 
-    return render_to_response('saml2idp/login.html', tv,
+    template_names = _get_template_names('login.html', processor)
+    return render_to_response(template_names,
+                              tv,
                               context_instance=RequestContext(request))
 
 
@@ -120,7 +140,8 @@ def logout(request):
     else:
         return HttpResponseRedirect(redirect_url)
 
-    return render_to_response('saml2idp/logged_out.html', {},
+    return render_to_response(_get_template_names('saml2idp/logged_out.html'),
+                              {},
                               context_instance=RequestContext(request))
 
 
@@ -140,7 +161,8 @@ def slo_logout(request):
     #XXX: For now, simply log out without validating the request.
     auth.logout(request)
     tv = {}
-    return render_to_response('saml2idp/logged_out.html', tv,
+    return render_to_response(_get_template_names('logged_out.html'),
+                              tv,
                               context_instance=RequestContext(request))
 
 
@@ -159,4 +181,6 @@ def descriptor(request):
         'slo_url': slo_url,
         'sso_url': sso_url
     }
-    return xml_response(request, 'saml2idp/idpssodescriptor.xml', tv)
+    return xml_response(request,
+                        os.path.join(BASE_TEMPLATE_DIR, 'idpssodescriptor.xml'),
+                        tv)

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -73,8 +73,8 @@ def login_init(request, resource, **kwargs):
     """
     Initiates an IdP-initiated link to a simple SP resource/target URL.
     """
-    sp_config = metadata.get_config_for_resource(resource)
-    proc = registry.get_processor(sp_config)
+    name, sp_config = metadata.get_config_for_resource(resource)
+    proc = registry.get_processor(name, sp_config)
 
     try:
         linkdict = dict(metadata.get_links(sp_config))


### PR DESCRIPTION
Currently there's only a single template available during the login process
that will be used for all the different clients. This makes it difficult to
specify custom templates for a client and address the correct audience. 

Django's templating system allows a list of template names to be used with
various render functions and will cycle trough the list and uses the first one
that it can find. This makes it possible to specify a processor-specific
template with a fallback to the standard one. 

The default template for `login.html` is expected to be in
`templates/saml2idp/login.html`, this PR extends that functionality and will
check for the template `templates/saml2idp/<processor_name>/login.html` first.
