### PR TITLE
An invalid SAML request causes a 500 error instead of showing a proper error page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 
 .env
 
+.cache
+.coverage
+
 # Python release artifacts
 build/
 dist/

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -31,17 +31,17 @@ class TestLoginView(TestCase):
         """
         GET request without SAMLResponse data should have failed.
         """
-        self.assertRaises(KeyError, lambda : self.client.get('/idp/login/'))
+        self.assertEquals(self.client.get('/idp/login/').status_code, 400)
 
     def test_empty_post(self):
         """
         POST request without SAMLResponse data should have failed.
         """
-        self.assertRaises(KeyError, lambda : self.client.post('/idp/login/'))
+        self.assertEquals(self.client.post('/idp/login/').status_code, 400)
 
     def _test_pre_redirect(self):
-        self.assertFalse(self.client.session.has_key('SAMLRequest'))
-        self.assertFalse(self.client.session.has_key('RelayState'))
+        self.assertFalse('SAMLRequest' in self.client.session)
+        self.assertFalse('RelayState' in self.client.session)
 
     def _test_redirect(self, response):
         self.assertEquals(response.status_code, HttpResponseRedirect.status_code)

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -6,7 +6,9 @@ from django.contrib import auth
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
+from django.utils.datastructures import MultiValueDictKeyError
 from django.shortcuts import render_to_response, redirect
+from django.http import HttpResponseBadRequest
 from django.template import RequestContext
 from django.views.decorators.csrf import csrf_exempt
 
@@ -47,7 +49,12 @@ def login_begin(request, *args, **kwargs):
     else:
         source = request.GET
     # Store these values now, because Django's login cycle won't preserve them.
-    request.session['SAMLRequest'] = source['SAMLRequest']
+
+    try:
+        request.session['SAMLRequest'] = source['SAMLRequest']
+    except (KeyError, MultiValueDictKeyError):
+        return HttpResponseBadRequest('the SAML request payload is missing')
+
     request.session['RelayState'] = source.get('RelayState', '')
     return redirect('saml_login_process')
 


### PR DESCRIPTION
When no SAML request is passed to the login view, the server reacts with a 500 error. That's not really nice and should be handled better. This needs to be handled better. Currently this happens:

``` python
MultiValueDictKeyError: "'SAMLRequest'"
  File "saml2idp/views.py", line 50, in login_begin
    request.session['SAMLRequest'] = source['SAMLRequest']
```
