### PR TITLE
Add structlog and improve the logging during request validation

### DIFF
--- a/saml2idp/base.py
+++ b/saml2idp/base.py
@@ -99,7 +99,7 @@ class Processor(object):
             'ASSERTION': self._assertion_xml,
             'ISSUE_INSTANT': get_time_string(),
             'RESPONSE_ID': self._response_id,
-            'RESPONSE_SIGNATURE': '', # initially unsigned
+            'RESPONSE_SIGNATURE': '',  # initially unsigned
         }
         self._response_params.update(self._system_params)
         self._response_params.update(self._request_params)
@@ -110,7 +110,8 @@ class Processor(object):
         """
         self._request_xml = base64.b64decode(self._saml_request)
 
-        self._logger.info('SAML request decoded', decoded_request=self._request_xml)
+        self._logger.debug('SAML request decoded',
+                           decoded_request=self._request_xml)
 
     def _determine_assertion_id(self):
         """

--- a/saml2idp/logging.py
+++ b/saml2idp/logging.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import structlog
+
+
+def get_saml_logger():
+    """
+    Get a logger named `saml2idp` after the main package.
+    """
+    return structlog.get_logger('saml2idp')

--- a/saml2idp/registry.py
+++ b/saml2idp/registry.py
@@ -3,17 +3,15 @@ from __future__ import absolute_import
 """
 Registers and loads Processor classes from settings.
 """
-import logging
-
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
 
 from . import exceptions
 from . import saml2idp_metadata
+from .logging import get_saml_logger
 
-
-logger = logging.getLogger(__name__)
+logger = get_saml_logger()
 
 
 def get_processor(config):
@@ -30,9 +28,9 @@ def get_processor(config):
     sp_module, sp_classname = dottedpath[:dot], dottedpath[dot+1:]
     try:
         mod = import_module(sp_module)
-    except ImportError, e:
+    except ImportError as exc:
         raise ImproperlyConfigured(
-            'Error importing processors {0}: "{1}"'.format(sp_module, e))
+            'Error importing processors {0}: "{1}"'.format(sp_module, exc))
     try:
         sp_class = getattr(mod, sp_classname)
     except AttributeError:

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import logging
-
 from django.contrib import auth
 from django.core.validators import URLValidator
 from django.contrib.auth.decorators import login_required
@@ -18,6 +16,9 @@ from . import exceptions
 from . import metadata
 from . import registry
 from . import xml_signing
+from .logging import get_saml_logger
+
+logger = get_saml_logger()
 
 # The 'schemes' argument for the URLValidator was introduced in Django 1.6. This
 # ensure that URL validation works in 1.5 as well.
@@ -96,7 +97,7 @@ def login_process(request):
     Processor-based login continuation.
     Presents a SAML 2.0 Assertion for POSTing back to the Service Provider.
     """
-    logging.debug("Request: %s" % request)
+    logger.debug("Request: %s" % request)
     proc = registry.find_processor(request)
     return _generate_response(request, proc)
 

--- a/saml2idp/xml_render.py
+++ b/saml2idp/xml_render.py
@@ -1,11 +1,22 @@
+# -*- coding: utf-8 -*-
 """
 Functions for creating XML output.
 """
-import logging
+from __future__ import absolute_import
 import string
-from xml_signing import get_signature_xml
-from xml_templates import ATTRIBUTE, ATTRIBUTE_STATEMENT, \
-    ASSERTION_GOOGLE_APPS, ASSERTION_SALESFORCE, RESPONSE, SUBJECT
+
+from .xml_signing import get_signature_xml
+from .xml_templates import (ATTRIBUTE,
+                            ATTRIBUTE_STATEMENT,
+                            ASSERTION_GOOGLE_APPS,
+                            ASSERTION_SALESFORCE,
+                            RESPONSE,
+                            SUBJECT)
+
+from .logging import get_saml_logger
+
+logger = get_saml_logger()
+
 
 def _get_attribute_statement(params):
     """
@@ -66,8 +77,8 @@ def _get_assertion_xml(template, parameters, signed=False):
     _get_attribute_statement(params)
 
     unsigned = template.substitute(params)
-    logging.debug('Unsigned:')
-    logging.debug(unsigned)
+    logger.debug('Unsigned:')
+    logger.debug(unsigned)
     if not signed:
         return unsigned
 
@@ -76,8 +87,8 @@ def _get_assertion_xml(template, parameters, signed=False):
     params['ASSERTION_SIGNATURE'] = signature_xml
     signed = template.substitute(params)
 
-    logging.debug('Signed:')
-    logging.debug(signed)
+    logger.debug('Signed:')
+    logger.debug(signed)
     return signed
 
 def get_assertion_googleapps_xml(parameters, signed=False):
@@ -99,8 +110,8 @@ def get_response_xml(parameters, signed=False):
     template = string.Template(RESPONSE)
     unsigned = template.substitute(params)
 
-    logging.debug('Unsigned:')
-    logging.debug(unsigned)
+    logger.debug('Unsigned:')
+    logger.debug(unsigned)
     if not signed:
         return unsigned
 
@@ -109,6 +120,6 @@ def get_response_xml(parameters, signed=False):
     params['RESPONSE_SIGNATURE'] = signature_xml
     signed = template.substitute(params)
 
-    logging.debug('Signed:')
-    logging.debug(signed)
+    logger.debug('Signed:')
+    logger.debug(signed)
     return signed

--- a/saml2idp/xml_signing.py
+++ b/saml2idp/xml_signing.py
@@ -4,13 +4,15 @@ Signing code goes here.
 """
 from __future__ import absolute_import
 import hashlib
-import logging
 import string
 import M2Crypto
 
 from . import saml2idp_metadata as smd
 from .codex import nice64
 from .xml_templates import SIGNED_INFO, SIGNATURE
+from .logging import get_saml_logger
+
+logger = get_saml_logger()
 
 
 def load_certificate(config):
@@ -18,7 +20,7 @@ def load_certificate(config):
         return config.get(smd.CERTIFICATE_DATA, '')
 
     certificate_filename = config.get(smd.CERTIFICATE_FILENAME)
-    logging.debug('Using certificate file: ' + certificate_filename)
+    logger.info('Using certificate file: ' + certificate_filename)
 
     certificate = M2Crypto.X509.load_cert(certificate_filename)
     return ''.join(certificate.as_pem().split('\n')[1:-2])
@@ -31,7 +33,7 @@ def load_private_key(config):
         return M2Crypto.EVP.load_key_string(private_key_data)
 
     private_key_file = config.get(smd.PRIVATE_KEY_FILENAME)
-    logging.debug('Using private key file: {}'.format(private_key_file))
+    logger.info('Using private key file: {}'.format(private_key_file))
 
     # The filename need to be encoded because it is using a C extension under
     # the hood which means it expects a 'const char*' type and will fail with
@@ -49,29 +51,29 @@ def get_signature_xml(subject, reference_uri):
     """
     Returns XML Signature for subject.
     """
-    logging.debug('get_signature_xml - Begin.')
+    logger.debug('get_signature_xml - Begin.')
     config = smd.SAML2IDP_CONFIG
 
     private_key = load_private_key(config)
     certificate = load_certificate(config)
 
-    logging.debug('Subject: ' + subject)
+    logger.debug('Subject: ' + subject)
 
     # Hash the subject.
     subject_hash = hashlib.sha1()
     subject_hash.update(subject)
     subject_digest = nice64(subject_hash.digest())
-    logging.debug('Subject digest: ' + subject_digest)
+    logger.debug('Subject digest: ' + subject_digest)
 
     # Create signed_info.
     signed_info = string.Template(SIGNED_INFO).substitute({
         'REFERENCE_URI': reference_uri,
         'SUBJECT_DIGEST': subject_digest,
         })
-    logging.debug('SignedInfo XML: ' + signed_info)
+    logger.debug('SignedInfo XML: ' + signed_info)
 
     rsa_signature = sign_with_rsa(private_key, signed_info)
-    logging.debug('RSA Signature: ' + rsa_signature)
+    logger.debug('RSA Signature: ' + rsa_signature)
 
     # Put the signed_info and rsa_signature into the XML signature.
     signed_info_short = signed_info.replace(' xmlns:ds="http://www.w3.org/2000/09/xmldsig#"', '')
@@ -80,5 +82,5 @@ def get_signature_xml(subject, reference_uri):
         'SIGNED_INFO': signed_info_short,
         'CERTIFICATE': certificate,
         })
-    logging.debug('Signature XML: ' + signature_xml)
+    logger.info('Signature XML: ' + signature_xml)
     return signature_xml

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         # We have to pin M2Crypto to version 0.22.3 because more recent
         # versions are failing due to issues with finding openssl libs.
         'M2Crypto==0.22.3',
-        'BeautifulSoup>=3.2.0'],
+        'BeautifulSoup>=3.2.0',
+        'structlog'],
     license='MIT',
     packages=['saml2idp'],
     url='http://github.com/mobify/dj-saml-idp',


### PR DESCRIPTION
At this point it's really tricky in a system using this package to identify why a SAML request was rejected because the log output can't be configured appropriatly. Since we are using `structlog` for our SAML-related projects, this introduces a new requirement for it.
