### PR TITLE
Allow redirect URL for logout endpoint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,13 @@ Release History
 ---------------
 
 
+0.21.3
+++++++
+
+* Allow a `redirect_to` parameter to be passed to the logout view to redirect
+  the user to after succesful logout instead of showing the logout page.
+
+
 0.21.2 (2016-04-18)
 +++++++++++++++++++
 

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -102,7 +102,7 @@ class TestLogoutView(TestCase):
                                    {'redirect_to': redirect_url})
 
         assert response.status_code == 302
-        assert response.url == redirect_url
+        assert response['Location'] == redirect_url
 
     def test_logout_redirect_with_invalid_url_fails(self):
         redirect_url = '://saml.serviceprovid.er/somewhere/'

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -88,6 +88,7 @@ class TestLoginProcessView(TestCase):
 
 
 class TestLogoutView(TestCase):
+
     def test_logout(self):
         """
         Response did not say logged out.
@@ -95,15 +96,37 @@ class TestLogoutView(TestCase):
         response = self.client.get('/idp/logout/')
         self.assertContains(response, 'logged out', status_code=200)
 
+    def test_logout_redirect(self):
+        redirect_url = 'https://saml.serviceprovid.er/somewhere/'
+        response = self.client.get('/idp/logout/',
+                                   {'redirect_to': redirect_url})
+
+        assert response.status_code == 302
+        assert response.url == redirect_url
+
+    def test_logout_redirect_with_invalid_url_fails(self):
+        redirect_url = '://saml.serviceprovid.er/somewhere/'
+        response = self.client.get('/idp/logout/',
+                                   {'redirect_to': redirect_url})
+
+        self.assertContains(response, 'logged out', status_code=200)
+
     def test_logout_user(self):
         """
         User account not logged out.
         """
-        fred = User.objects.create_user('fred', email='fred@example.com', password='secret')
+        User.objects.create_user('fred',
+                                 email='fred@example.com',
+                                 password='secret')
+
         self.client.login(username='fred', password='secret')
-        self.assertTrue('_auth_user_id' in self.client.session, 'Did not login test user; test is broken.')
-        response = self.client.get('/idp/logout/')
-        self.assertTrue('_auth_user_id' not in self.client.session, 'Did not logout test user.')
+        self.assertTrue('_auth_user_id' in self.client.session,
+                        'Did not login test user; test is broken.')
+
+        self.client.get('/idp/logout/')
+
+        self.assertTrue('_auth_user_id' not in self.client.session,
+                        'Did not logout test user.')
 
 
 def test_rendering_metadata_view(client):

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -111,14 +111,13 @@ def logout(request):
     auth.logout(request)
 
     redirect_url = request.GET.get('redirect_to', '')
-    if redirect_url:
 
-        try:
-            validator = URL_VALIDATOR(redirect_url)
-        except ValidationError:
-            pass
-        else:
-            return HttpResponseRedirect(redirect_url)
+    try:
+        URL_VALIDATOR(redirect_url)
+    except ValidationError:
+        pass
+    else:
+        return HttpResponseRedirect(redirect_url)
 
     return render_to_response('saml2idp/logged_out.html', {},
                               context_instance=RequestContext(request))

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -19,6 +19,13 @@ from . import metadata
 from . import registry
 from . import xml_signing
 
+# The 'schemes' argument for the URLValidator was introduced in Django 1.6. This
+# ensure that URL validation works in 1.5 as well.
+try:
+    URL_VALIDATOR = URLValidator(schemes=('http', 'https'))
+except TypeError:
+    URL_VALIDATOR = URLValidator()
+
 
 def _generate_response(request, processor):
     """
@@ -105,10 +112,9 @@ def logout(request):
 
     redirect_url = request.GET.get('redirect_to', '')
     if redirect_url:
-        validator = URLValidator(schemes=('http', 'https'))
 
         try:
-            validator(redirect_url)
+            validator = URL_VALIDATOR(redirect_url)
         except ValidationError:
             pass
         else:


### PR DESCRIPTION
The logout URL for the SAML IDP provider shows a page indication to the user
that they are logged out now. For some services we'd like to be able to pass
a URL to redirect to, which allows us to point the user back to the services
provider they came from. 

This PR adds the ability to provide a `redirect_to` GET parameter on the
logout URL and redirect to that instead of showing the logout page. 

To avoid misuse, we ensure that anything that's passed as `redirect_to` URL is
a valid HTTP/HTTPS URL using the Django URLValidator.

Status: **Ready for Review**
## Reviewers 
- Engineer: @noahadams @dbader
