### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: true
 language: python
+cache: pip
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 sudo: true
 language: python
 
-addons:
-  apt:
-    packages:
-      - swig
-
 matrix:
   include:
     - env: TOXENV=py27-dj15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,35 @@
 sudo: true
 language: python
-python:
-    - "2.7"
+
 addons:
   apt:
     packages:
       - swig
 
-env:
-    matrix:
-      - TOXENV=py27-dj15
-      - TOXENV=py27-dj16
-      - TOXENV=py27-dj17
-      - TOXENV=py27-dj18
-      - TOXENV=py27-dj19
+matrix:
+  include:
+    - env: TOXENV=py27-dj15
+      python: 2.7
+    - env: TOXENV=py27-dj16
+      python: 2.7
+    - env: TOXENV=py27-dj17
+      python: 2.7
+    - env: TOXENV=py27-dj18
+      python: 2.7
+    - env: TOXENV=py27-dj19
+      python: 2.7
+    - env: TOXENV=py34-dj17
+      python: 3.4
+    - env: TOXENV=py34-dj18
+      python: 3.4
+    - env: TOXENV=py34-dj19
+      python: 3.4
+    - env: TOXENV=py34-dj15
+      python: 3.4
+    - env: TOXENV=py35-dj18
+      python: 3.5
+    - env: TOXENV=py35-dj19
+      python: 3.5
 
 install:
     - pip install tox

--- a/idptest/manage.py
+++ b/idptest/manage.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 

--- a/idptest/scripts/c14n.py
+++ b/idptest/scripts/c14n.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.utils.six import StringIO
 from lxml import etree

--- a/idptest/scripts/c14n.py
+++ b/idptest/scripts/c14n.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 from __future__ import print_function
 
-from StringIO import StringIO
+from django.utils.six import StringIO
 from lxml import etree
 
 

--- a/idptest/scripts/c14n.py
+++ b/idptest/scripts/c14n.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
+from __future__ import print_function
+
 from StringIO import StringIO
 from lxml import etree
+
 
 def c14n(src):
     f = StringIO(src)
@@ -18,8 +21,8 @@ if __name__=="__main__":
 
     (options, args) = parser.parse_args()
     if len(args) < 1:
-        print "c14n - Canonicalize an XML file to stdout"
-        print "Usage: c14n [--fix] FILENAMES"
+        print("c14n - Canonicalize an XML file to stdout")
+        print("Usage: c14n [--fix] FILENAMES")
     else:
         for filename in args:
            # print 'Processing ' + filename + '...'
@@ -31,6 +34,6 @@ if __name__=="__main__":
                 g = open(filename, "w")
                 g.write(fixed)
                 g.close()
-                print "Fixed " + filename
+                print("Fixed " + filename)
             else:
-                print c14n(data)
+                print(c14n(data))

--- a/idptest/settings.py
+++ b/idptest/settings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 # Django settings for idptest project.
 
 DEBUG = True

--- a/idptest/tests/base.py
+++ b/idptest/tests/base.py
@@ -3,7 +3,7 @@
 Tests for the Base Processor class.
 """
 from __future__ import absolute_import
-from BeautifulSoup import BeautifulSoup, BeautifulStoneSoup
+from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -46,11 +46,11 @@ class SamlTestCase(TestCase):
 
         response = self.client.get(url, data=data, follow=True)
         html = response.content
-        soup = BeautifulSoup(html)
+        soup = BeautifulSoup(html, 'html.parser')
         inputtag = soup.findAll('input', {'name':'SAMLResponse'})[0]
         encoded_response = inputtag['value']
         saml = codex.base64.b64decode(encoded_response)
-        saml_soup = BeautifulStoneSoup(saml)
+        saml_soup = BeautifulSoup(saml, features='xml')
 
         self._html = html
         self._html_soup = soup

--- a/idptest/tests/base.py
+++ b/idptest/tests/base.py
@@ -49,7 +49,7 @@ class SamlTestCase(TestCase):
         soup = BeautifulSoup(html, 'html.parser')
         inputtag = soup.findAll('input', {'name':'SAMLResponse'})[0]
         encoded_response = inputtag['value']
-        saml = codex.base64.b64decode(encoded_response)
+        saml = codex.base64.b64decode(encoded_response).decode('utf8')
         saml_soup = BeautifulSoup(saml, features='xml')
 
         self._html = html

--- a/idptest/tests/base.py
+++ b/idptest/tests/base.py
@@ -2,7 +2,8 @@
 """
 Tests for the Base Processor class.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/idptest/tests/test_deeplink.py
+++ b/idptest/tests/test_deeplink.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 """
 Tests for the demo AttributeProcessor and IdP-initiated deep-linking.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from . import base
 
 

--- a/idptest/tests/test_deeplink.py
+++ b/idptest/tests/test_deeplink.py
@@ -36,10 +36,11 @@ class TestDeepLinkWithAttributes(TestDeepLink):
 
     def test_deeplink(self):
         super(TestDeepLinkWithAttributes, self).test_deeplink()
-        attributes = self._saml_soup.findAll('saml:attribute')
+        attributes = self._saml_soup.findAll('Attribute')
 
         # Assert.
         self.assertEqual(len(attributes), 1)
-        self.assertEqual(attributes[0]['name'], 'foo')
-        value = attributes[0].findAll('saml:attributevalue')[0]
+        self.assertEqual(attributes[0].namespace, "urn:oasis:names:tc:SAML:2.0:assertion")
+        self.assertEqual(attributes[0]['Name'], 'foo')
+        value = attributes[0].findAll('AttributeValue')[0]
         self.assertEqual(value.text, 'bar')

--- a/idptest/tests/test_google_apps.py
+++ b/idptest/tests/test_google_apps.py
@@ -1,6 +1,8 @@
 """
 Tests for the Google Apps processor.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from . import base
 from saml2idp import codex
 

--- a/idptest/tests/test_metadata.py
+++ b/idptest/tests/test_metadata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 
 from django.core.exceptions import ImproperlyConfigured

--- a/idptest/tests/test_processor.py
+++ b/idptest/tests/test_processor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 
 from django.core.exceptions import ImproperlyConfigured

--- a/idptest/tests/test_registry.py
+++ b/idptest/tests/test_registry.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from mock import patch
 
 from saml2idp import registry

--- a/idptest/tests/test_salesforce.py
+++ b/idptest/tests/test_salesforce.py
@@ -4,7 +4,7 @@ Tests for the SalesForce processor.
 # standard library imports:
 import base64
 # local imports:
-import base
+from . import base
 
 SAML_REQUEST = base64.b64encode(
     '<?xml version="1.0" encoding="UTF-8"?>'

--- a/idptest/tests/test_salesforce.py
+++ b/idptest/tests/test_salesforce.py
@@ -1,6 +1,8 @@
 """
 Tests for the SalesForce processor.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 # standard library imports:
 import base64
 # local imports:

--- a/idptest/tests/test_salesforce.py
+++ b/idptest/tests/test_salesforce.py
@@ -6,7 +6,7 @@ import base64
 # local imports:
 from . import base
 
-SAML_REQUEST = base64.b64encode(
+SAML_REQUEST = base64.b64encode((
     '<?xml version="1.0" encoding="UTF-8"?>'
     '<samlp:AuthnRequest '
     'AssertionConsumerServiceURL="https://login.salesforce.com" '
@@ -66,7 +66,8 @@ SAML_REQUEST = base64.b64encode(
     'sDB4siloTOcJ25/NsfPRoWDyvwax0aXDzsBRwJ5Qpr+ii3bUI1+QByEdxH4gZVHHu9fMG/+ePr9S'
     'Hhil20oycE7oe0xvQEad1Hs6xHCRDbJVIr4=</ds:X509Certificate></ds:X509Data>'
     '</ds:KeyInfo></ds:Signature></samlp:AuthnRequest>'
-    )
+).encode('utf8'))
+
 RELAY_STATE = '/home/home.jsp'
 REQUEST_DATA = {
     'SAMLRequest': SAML_REQUEST,

--- a/idptest/tests/test_signing.py
+++ b/idptest/tests/test_signing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import string
 import unittest
@@ -148,7 +149,7 @@ def test_loading_private_key():
     filename = os.path.join(os.getcwd(), 'keys/sample/sample-private-key.pem')
     config = {smd.PRIVATE_KEY_FILENAME: filename}
 
-    assert type(filename) is str  # This correctly differs on py2/py3
+    assert type(filename) is text_type
     xml_signing.load_private_key(config)
 
     filename = text_type(filename)
@@ -171,7 +172,7 @@ def test_loading_certificate_from_file():
     filename = os.path.join(os.getcwd(), 'keys/sample/sample-certificate.pem')
     config = {smd.CERTIFICATE_FILENAME: filename}
 
-    assert type(filename) is str  # This correctly differs on py2/py3
+    assert type(filename) is text_type
     xml_signing.load_certificate(config)
 
     filename = text_type(filename)

--- a/idptest/tests/test_signing.py
+++ b/idptest/tests/test_signing.py
@@ -4,6 +4,7 @@ import os
 import string
 import unittest
 
+from django.utils.six import text_type
 from saml2idp import xml_render
 from saml2idp import xml_signing
 from saml2idp import saml2idp_metadata as smd
@@ -147,10 +148,10 @@ def test_loading_private_key():
     filename = os.path.join(os.getcwd(), 'keys/sample/sample-private-key.pem')
     config = {smd.PRIVATE_KEY_FILENAME: filename}
 
-    assert type(filename) is str
+    assert type(filename) is str  # This correctly differs on py2/py3
     xml_signing.load_private_key(config)
 
-    filename = unicode(filename)
+    filename = text_type(filename)
     config = {smd.PRIVATE_KEY_FILENAME: filename}
     xml_signing.load_private_key(config)
 
@@ -170,10 +171,10 @@ def test_loading_certificate_from_file():
     filename = os.path.join(os.getcwd(), 'keys/sample/sample-certificate.pem')
     config = {smd.CERTIFICATE_FILENAME: filename}
 
-    assert type(filename) is str
+    assert type(filename) is str  # This correctly differs on py2/py3
     xml_signing.load_certificate(config)
 
-    filename = unicode(filename)
+    filename = text_type(filename)
     config = {smd.CERTIFICATE_FILENAME: filename}
 
     certificate = xml_signing.load_certificate(config)

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -34,20 +34,20 @@ class TestLoginView(TestCase):
         """
         GET request without SAMLResponse data should have failed.
         """
-        self.assertEquals(self.client.get('/idp/login/').status_code, 400)
+        self.assertEqual(self.client.get('/idp/login/').status_code, 400)
 
     def test_empty_post(self):
         """
         POST request without SAMLResponse data should have failed.
         """
-        self.assertEquals(self.client.post('/idp/login/').status_code, 400)
+        self.assertEqual(self.client.post('/idp/login/').status_code, 400)
 
     def _test_pre_redirect(self):
         self.assertFalse('SAMLRequest' in self.client.session)
         self.assertFalse('RelayState' in self.client.session)
 
     def _test_redirect(self, response):
-        self.assertEquals(response.status_code, HttpResponseRedirect.status_code)
+        self.assertEqual(response.status_code, HttpResponseRedirect.status_code)
         self.assertTrue(response['location'].endswith('/idp/login/process/'))
         self.assertEqual(self.client.session['SAMLRequest'], SAML_REQUEST)
         self.assertEqual(self.client.session['RelayState'], RELAY_STATE)

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -6,7 +6,8 @@ NOTE: These classes do not test anything SAML-related.
 Testing actual SAML functionality requires implementation-specific details,
 which should be put in another test module.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import mock
 import pytest

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -134,7 +134,8 @@ class TestLogoutView(TestCase):
 
 def test_rendering_metadata_view(client):
     page = client.get(reverse('metadata_xml'))
-    assert load_certificate(smd.SAML2IDP_CONFIG) in page.content
+    cert = load_certificate(smd.SAML2IDP_CONFIG).encode('ascii')
+    assert cert in page.content
 
 
 def test_creating_template_names_without_processor():

--- a/idptest/urls.py
+++ b/idptest/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from django.conf.urls import patterns, include
 
 # Uncomment the next two lines to enable the admin:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-django
-pytest-cover
+pytest-cov
 pdbpp
 tox
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest
 pytest-django
 pytest-cov
-pdbpp
 tox
 
 # Release tools

--- a/saml2idp/__init__.py
+++ b/saml2idp/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __version__ = '0.22.0'

--- a/saml2idp/base.py
+++ b/saml2idp/base.py
@@ -4,7 +4,7 @@ import base64
 import time
 import uuid
 
-from BeautifulSoup import BeautifulStoneSoup
+from bs4 import BeautifulSoup
 from django.core.exceptions import ImproperlyConfigured
 
 from . import codex
@@ -192,13 +192,13 @@ class Processor(object):
         if not self._request_xml.strip().startswith('<'):
             raise Exception('RequestXML is not valid XML; '
                             'it may need to be decoded or decompressed.')
-        soup = BeautifulStoneSoup(self._request_xml)
+        soup = BeautifulSoup(self._request_xml, 'xml')
         request = soup.findAll()[0]
         params = {}
-        params['ACS_URL'] = request['assertionconsumerserviceurl']
-        params['REQUEST_ID'] = request['id']
-        params['DESTINATION'] = request.get('destination', '')
-        params['PROVIDER_NAME'] = request.get('providername', '')
+        params['ACS_URL'] = request['AssertionConsumerServiceURL']
+        params['REQUEST_ID'] = request['ID']
+        params['DESTINATION'] = request.get('Destination', '')
+        params['PROVIDER_NAME'] = request.get('ProviderName', '')
         self._request_params = params
 
     def _reset(self, django_request, sp_config=None):

--- a/saml2idp/base.py
+++ b/saml2idp/base.py
@@ -150,7 +150,7 @@ class Processor(object):
         """
         Encodes _response_xml to _encoded_xml.
         """
-        self._saml_response = codex.nice64(self._response_xml)
+        self._saml_response = codex.nice64(self._response_xml.encode('utf8'))
 
     def _extract_saml_request(self):
         """
@@ -189,7 +189,7 @@ class Processor(object):
         Parses various parameters from _request_xml into _request_params.
         """
         #Minimal test to verify that it's not binarily encoded still:
-        if not self._request_xml.strip().startswith('<'):
+        if not self._request_xml.strip().startswith(b'<'):
             raise Exception('RequestXML is not valid XML; '
                             'it may need to be decoded or decompressed.')
         soup = BeautifulSoup(self._request_xml, 'xml')

--- a/saml2idp/base.py
+++ b/saml2idp/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import base64
 import time
 import uuid

--- a/saml2idp/codex.py
+++ b/saml2idp/codex.py
@@ -3,15 +3,21 @@
 import zlib
 import base64
 
-def decode_base64_and_inflate( b64string ):
-    decoded_data = base64.b64decode( b64string )
-    return zlib.decompress( decoded_data , -15)
+from django.utils.six import binary_type
 
-def deflate_and_base64_encode( string_val ):
-    zlibbed_str = zlib.compress( string_val )
+
+def decode_base64_and_inflate(b64string):
+    decoded_data = base64.b64decode(b64string)
+    return zlib.decompress(decoded_data, -15)
+
+
+def deflate_and_base64_encode(string_val):
+    zlibbed_str = zlib.compress(string_val.encode('utf8'))
     compressed_string = zlibbed_str[2:-4]
-    return base64.b64encode( compressed_string )
+    return base64.b64encode(compressed_string)
+
 
 def nice64(src):
     """ Returns src base64-encoded and formatted nicely for our XML. """
-    return src.encode('base64').replace('\n', '')
+    assert isinstance(src, binary_type), 'Can only encode bytes'
+    return base64.b64encode(src).decode('ascii')

--- a/saml2idp/codex.py
+++ b/saml2idp/codex.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 # Portions borrowed from:
 # http://stackoverflow.com/questions/1089662/python-inflate-and-deflate-implementations
 import zlib

--- a/saml2idp/demo.py
+++ b/saml2idp/demo.py
@@ -1,6 +1,6 @@
-import base
-import exceptions
-import xml_render
+from . import base
+from . import exceptions
+from . import xml_render
 
 class Processor(base.Processor):
     """

--- a/saml2idp/demo.py
+++ b/saml2idp/demo.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from . import base
 from . import exceptions
 from . import xml_render

--- a/saml2idp/exceptions.py
+++ b/saml2idp/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 class CannotHandleAssertion(Exception):
     """
     This processor does not handle this assertion.

--- a/saml2idp/google_apps.py
+++ b/saml2idp/google_apps.py
@@ -1,7 +1,7 @@
-import base
-import codex
-import exceptions
-import xml_render
+from . import base
+from . import codex
+from . import exceptions
+from . import xml_render
 
 class Processor(base.Processor):
     """

--- a/saml2idp/google_apps.py
+++ b/saml2idp/google_apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from . import base
 from . import codex
 from . import exceptions

--- a/saml2idp/logging.py
+++ b/saml2idp/logging.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import structlog
 
 

--- a/saml2idp/metadata.py
+++ b/saml2idp/metadata.py
@@ -1,6 +1,8 @@
 """
 Query metadata from settings.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 # Django imports
 from django.core.exceptions import ImproperlyConfigured
 # Local imports

--- a/saml2idp/metadata.py
+++ b/saml2idp/metadata.py
@@ -4,7 +4,7 @@ Query metadata from settings.
 # Django imports
 from django.core.exceptions import ImproperlyConfigured
 # Local imports
-from saml2idp_metadata import SAML2IDP_CONFIG, SAML2IDP_REMOTES
+from .saml2idp_metadata import SAML2IDP_CONFIG, SAML2IDP_REMOTES
 
 def get_config_for_acs(acs_url):
     """

--- a/saml2idp/registry.py
+++ b/saml2idp/registry.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 """
 Registers and loads Processor classes from settings.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import warnings
 
 from importlib import import_module

--- a/saml2idp/salesforce.py
+++ b/saml2idp/salesforce.py
@@ -1,6 +1,6 @@
-import base
-import exceptions
-import xml_render
+from . import base
+from . import exceptions
+from . import xml_render
 
 class Processor(base.Processor):
     """

--- a/saml2idp/salesforce.py
+++ b/saml2idp/salesforce.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from . import base
 from . import exceptions
 from . import xml_render

--- a/saml2idp/saml2idp_metadata.py
+++ b/saml2idp/saml2idp_metadata.py
@@ -3,6 +3,8 @@ Django Settings that more closely resemble SAML Metadata.
 
 Detailed discussion is in doc/SETTINGS_AND_METADATA.txt.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/saml2idp/shib.py
+++ b/saml2idp/shib.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from . import base
 from . import xml_render
 import zlib

--- a/saml2idp/shib.py
+++ b/saml2idp/shib.py
@@ -1,5 +1,5 @@
-import base
-import xml_render
+from . import base
+from . import xml_render
 import zlib
 import base64
 

--- a/saml2idp/urls.py
+++ b/saml2idp/urls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from django.conf.urls import patterns, url
 from .views import descriptor, login_begin, login_init, login_process, logout
 from .metadata import get_deeplink_resources

--- a/saml2idp/urls.py
+++ b/saml2idp/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
-from views import descriptor, login_begin, login_init, login_process, logout
-from metadata import get_deeplink_resources
+from .views import descriptor, login_begin, login_init, login_process, logout
+from .metadata import get_deeplink_resources
 
 def deeplink_url_patterns(
     prefix='',

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 
 from django.contrib import auth

--- a/saml2idp/xml_render.py
+++ b/saml2idp/xml_render.py
@@ -2,7 +2,8 @@
 """
 Functions for creating XML output.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import string
 
 from .xml_signing import get_signature_xml

--- a/saml2idp/xml_signing.py
+++ b/saml2idp/xml_signing.py
@@ -2,13 +2,14 @@
 """
 Signing code goes here.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import base64
 import hashlib
 import string
 
 import OpenSSL.crypto
-from django.utils.six import text_type
+from django.utils import six
 
 from . import saml2idp_metadata as smd
 from .codex import nice64
@@ -52,7 +53,11 @@ def load_private_key(config):
 
 
 def sign_with_rsa(private_key, data):
-    data = OpenSSL.crypto.sign(private_key, data, "sha1")
+    digest = "sha1"
+    # This needs to be bytes on py2, str on py3. This is very odd.
+    if six.PY2:
+        digest = digest.encode('ascii')
+    data = OpenSSL.crypto.sign(private_key, data, digest)
     return base64.b64encode(data).decode('ascii')
 
 
@@ -70,7 +75,7 @@ def get_signature_xml(subject, reference_uri):
     logger.debug('Subject: %s' % (subject,))
 
     # Hash the subject.
-    if isinstance(subject, text_type):
+    if isinstance(subject, six.text_type):
         subject = subject.encode()
 
     subject_hash = hashlib.sha1()

--- a/saml2idp/xml_signing.py
+++ b/saml2idp/xml_signing.py
@@ -60,29 +60,33 @@ def get_signature_xml(subject, reference_uri):
     """
     Returns XML Signature for subject.
     """
+
     logger.debug('get_signature_xml - Begin.')
     config = smd.SAML2IDP_CONFIG
 
     private_key = load_private_key(config)
     certificate = load_certificate(config)
 
-    logger.debug('Subject: ' + subject)
+    logger.debug('Subject: %s' % (subject,))
 
     # Hash the subject.
+    if isinstance(subject, text_type):
+        subject = subject.encode()
+
     subject_hash = hashlib.sha1()
     subject_hash.update(subject)
     subject_digest = nice64(subject_hash.digest())
-    logger.debug('Subject digest: ' + subject_digest)
+    logger.debug('Subject digest: %s' % (subject_digest,))
 
     # Create signed_info.
     signed_info = string.Template(SIGNED_INFO).substitute({
         'REFERENCE_URI': reference_uri,
         'SUBJECT_DIGEST': subject_digest,
-        })
-    logger.debug('SignedInfo XML: ' + signed_info)
+    })
+    logger.debug('SignedInfo XML: %s' % (signed_info,))
 
     rsa_signature = sign_with_rsa(private_key, signed_info)
-    logger.debug('RSA Signature: ' + rsa_signature)
+    logger.debug('RSA Signature: %s' % (rsa_signature,))
 
     # Put the signed_info and rsa_signature into the XML signature.
     signed_info_short = signed_info.replace(' xmlns:ds="http://www.w3.org/2000/09/xmldsig#"', '')
@@ -90,6 +94,6 @@ def get_signature_xml(subject, reference_uri):
         'RSA_SIGNATURE': rsa_signature,
         'SIGNED_INFO': signed_info_short,
         'CERTIFICATE': certificate,
-        })
-    logger.info('Signature XML: ' + signature_xml)
+    })
+    logger.info('Signature XML: %s' % (signature_xml,))
     return signature_xml

--- a/saml2idp/xml_templates.py
+++ b/saml2idp/xml_templates.py
@@ -16,6 +16,8 @@ NOTE #3: I'm now leaning towards using lxml's E factory to do some of this.
     Look at the docs here: http://lxml.de/tutorial.html#the-e-factory
     Compare how the other python/saml libraries are using lxml.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 SIGNED_INFO = (
     '<ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">'
         '<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
-import saml2idp
 
+import saml2idp
 
 with open('README.rst') as readme:
     description = readme.read()
@@ -23,7 +23,8 @@ setup(
         # We have to pin M2Crypto to version 0.22.3 because more recent
         # versions are failing due to issues with finding openssl libs.
         'M2Crypto==0.22.3',
-        'BeautifulSoup>=3.2.0',
+        'BeautifulSoup4>=4.4.0',
+        'lxml',
         'structlog'],
     license='MIT',
     packages=['saml2idp'],

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,7 @@ setup(
     long_description='\n\n'.join([description, changelog]),
     install_requires=[
         'Django>=1.4',
-        # We have to pin M2Crypto to version 0.22.3 because more recent
-        # versions are failing due to issues with finding openssl libs.
-        'M2Crypto==0.22.3',
+        'pyopenssl>=0.16',
         'BeautifulSoup4>=4.4.0',
         'lxml',
         'structlog'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,14 @@
 skipsdist = True
 usedevelop = True
 minversion = 1.8
-envlist = py27-dj{15,16,17,18,19}
+envlist =
+    py27-dj{15,16,17,18,19}
+    py34-dj{17,18,19}
+    py35-dj{18,19}
 
 [testenv]
 setenv =
-    DJANGO_SETTINGS_MODULE = settings 
+    DJANGO_SETTINGS_MODULE = settings
 changedir=idptest
 usedevelop=true
 deps=


### PR DESCRIPTION
A project I am working on requires SAML, and is running on Python 3. I've ported this project to run on both Python 2 and Python 3. Each commit is self contained and hopefully gives enough context for review. Some of the notable changes are:
- Upgrade BeautifulSoup to version 4, as v3 is not py3 compatible. BS4 uses a more strict XML parser, which is case sensitive. It also treats namespaces a little oddly, dropping the prefix, but keeping the NSURI.
- Use pyopenssl over M2Crypto, as M2Crypto does not support Python 3.
- There were inevitably some `bytes` vs. `str` issues that turned up when running on Python 3. These have been resolved by explicitly creating `str`s or `bytes`, or by calling `.encode()`/`.decode()` as required.

This change should be 100% backwards compatible with Python 2. The test cases barely had to change, which is a good sign.

I will happily update the PR if you have any feedback or comments on the changes.
