### PR TITLE
updates mcrypto version to fix osx install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Django>=1.4',
         # We have to pin M2Crypto to version 0.22.3 because more recent
         # versions are failing due to issues with finding openssl libs.
-        'M2Crypto==0.22.3',
+        'M2Crypto==0.26.0',
         'BeautifulSoup>=3.2.0',
         'structlog'],
     license='MIT',


### PR DESCRIPTION
fixes issue https://stackoverflow.com/questions/31762106/swig-unable-to-find-openssl-conf