### PR TITLE
Update to support Django 2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = true
 tag = true
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = true
 tag = true
 tag_name = {new_version}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ is make sure that all the test are passing and that the version in
 
 With that done, all you need to do is run the following commands::
 
-`$ make release`
+```
+$ rm -rf build/ dist/ dj_saml_idp.egg-info
+$ make release
+```
 
 This will cleanup the `build/` and `dist/` directories, build a source package
 and a Python wheel. Both will then be uploaded to PyPI.

--- a/idptest/settings.py
+++ b/idptest/settings.py
@@ -83,20 +83,14 @@ TEMPLATES = [
     }
 ]
 
-if VERSION[:2] >= (1, 10):
-    MIDDLEWARE = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-    )
-else:
-    MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-    )
+# Django2+ uses MIDDLEWARE rather than MIDDLEWARE_CLASSES, but it's
+# safe to define both.
+MIDDLEWARE = MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+)
 
 
 ROOT_URLCONF = 'idptest.urls'

--- a/idptest/settings.py
+++ b/idptest/settings.py
@@ -11,6 +11,8 @@ MANAGERS = ADMINS
 
 import os
 
+from django import VERSION
+
 # In this package, PROJECT_ROOT is the idptest directory itself.
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -81,12 +83,21 @@ TEMPLATES = [
     }
 ]
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-)
+if VERSION[:2] >= (1, 10):
+    MIDDLEWARE = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+    )
+else:
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+    )
+
 
 ROOT_URLCONF = 'idptest.urls'
 

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -13,7 +13,11 @@ import pytest
 
 from django.http import HttpResponseRedirect
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django import VERSION
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import six
 

--- a/idptest/tests/test_views.py
+++ b/idptest/tests/test_views.py
@@ -13,10 +13,9 @@ import pytest
 
 from django.http import HttpResponseRedirect
 from django.contrib.auth.models import User
-from django import VERSION
-if VERSION[:2] >= (1, 10):
+try:
     from django.urls import reverse
-else:
+except ImportError:
     from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import six

--- a/idptest/urls.py
+++ b/idptest/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     # (r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
     # Uncomment the next line to enable the admin:
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 
     # Required for login:
     url(r'^accounts/login/$', login),

--- a/saml2idp/__init__.py
+++ b/saml2idp/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/saml2idp/__init__.py
+++ b/saml2idp/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -7,7 +7,11 @@ from django.contrib import auth
 from django.core.validators import URLValidator
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.core.urlresolvers import reverse
+from django import VERSION
+if VERSION[:2] >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.shortcuts import render, redirect
 from django.http import HttpResponseBadRequest, HttpResponseRedirect

--- a/saml2idp/views.py
+++ b/saml2idp/views.py
@@ -7,10 +7,9 @@ from django.contrib import auth
 from django.core.validators import URLValidator
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django import VERSION
-if VERSION[:2] >= (1, 10):
+try:
     from django.urls import reverse
-else:
+except ImportError:
     from django.core.urlresolvers import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.shortcuts import render, redirect

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = false
 minversion = 3.14.0
-envlist = py27-dj{19,111},py37-dj{19,111}
+envlist = py27-dj{19,111},py37-dj{111,228}
 toxworkdir = /tox
 temp_dir = /tmp
 distdir = /app/dist
@@ -14,10 +14,11 @@ deps=
     M2Crypto==0.35.2
     beautifulsoup4>=4.8.1
     structlog==16.1.0
-    lxml==4.4.1
+    lxml==4.4.2
     -r{toxinidir}/requirements-dev.txt
     dj19: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
     dj111: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
+    dj228: https://www.djangoproject.com/download/2.2.8/tarball/#egg=django
 commands=py.test {posargs}
 
 [testenv:py27]


### PR DESCRIPTION
Update to support Django 1 and Django 2

Changes
-------
* Added conditionals to support django1 and django2.
* Fixed some django2 warnings 


How to test-drive this PR
-------------------------
Follow the "Development And Testing" section on the readme: https://github.com/mobify/dj-saml-idp#development-and-testing
1. Build and run the container.
```
docker build -t dj-saml-idp:latest .
docker-compose run --service-ports test
```
2. Choose the virtual environment for Python 3.7: `. /venv37/bin/activate`
3. Run the tests inside the container running: `tox`
